### PR TITLE
Fix/missing description and broken md layout

### DIFF
--- a/components/Reference/DocRow.tsx
+++ b/components/Reference/DocRow.tsx
@@ -107,6 +107,13 @@ const DocRow = ({
                 'flex-1 lg:pr-8': referenceItem.dynamicFee,
               })}
             >
+              {referenceItem.description && (
+                <div className="mb-6">
+                  <h2 className="text-lg font-medium mb-4">Description</h2>
+                  <p>{referenceItem.description}</p>
+                </div>
+              )}
+
               <MDXRemote {...itemDoc.mdxSource} components={docComponents} />
               {dynamicFeeForkName && dynamicFeeDocMdx && (
                 <MDXRemote

--- a/components/Reference/columns.tsx
+++ b/components/Reference/columns.tsx
@@ -42,7 +42,7 @@ const columns = (isPrecompiled: boolean) => [
       />
     ),
     width: 200,
-    className: 'hidden lg:table-cell',
+    className: 'hidden md:table-cell',
   },
   {
     Header: !isPrecompiled ? 'Stack Output' : 'Output',
@@ -54,7 +54,7 @@ const columns = (isPrecompiled: boolean) => [
       />
     ),
     width: 100,
-    className: 'hidden lg:table-cell',
+    className: 'hidden md:table-cell',
   },
   {
     Header: 'Description',


### PR DESCRIPTION
This pr includes two fixes:

## 50f89aff581ffbc3278b90a458b1baa158805569

### Issue
Descriptions are missing in the expanded view, which is not a problem on larger screens but confusing on mobile view. For example, for `RETURNDATACOPY`, without the description it's very confusing (for opcode learners like me) what this Opcode does.

<img width="386" alt="image" src="https://github.com/user-attachments/assets/9fec7b46-e538-4fbb-8aae-ecce63f820da" />

### Fix
Added description sections to all expanded section, no matter mobile view or not. 
I reused descriptions directly `referenceItem` since descriptions aren't part of md files.

<img width="383" alt="image" src="https://github.com/user-attachments/assets/487498ce-4116-4804-8513-8db13226b12b" />

- For full-screen users, having the description in the expanded section is also nice that we don't have to glance to the top-right section for it

<img width="1102" alt="image" src="https://github.com/user-attachments/assets/130bfa48-b1a5-47ea-90de-0ebb62d79df6" />


## 18ee26f4461ecc8a5863086c0d605a36fcb36e93

### Issue
For screen width >= 768 && < 1024, the column layout is squeezed together.

<img width="1058" alt="image" src="https://github.com/user-attachments/assets/75516a21-1368-4d52-8a0a-5a9f50a2d7a0" />

### Fix
Change breakpoints of `Input` & `Output` from `lg` to `md` s.t. there's not unintended gap when it's `md` view.

- `width == 768`: columns are rather tight but maybe acceptable?

<img width="801" alt="image" src="https://github.com/user-attachments/assets/a4486508-1019-4463-88b9-51e0f4511b57" />

- `width == 1023`

<img width="1056" alt="image" src="https://github.com/user-attachments/assets/3d33f2a2-be9e-47cd-af6a-2e6acf3cf655" />

---
If further improvements should be made to the commits, please lmk and I'm v happy to help since this website serves me (and i believe many) tremendous help for learning about EVM, bytecode and Huff!

Btw the reason why I use mobile view is that I keep the browser on the left and code editor on the right s.t. I can easily write Huff code based on the info on the left, which made me to want to help fix this issue to improve mobile/ smaller screen view users' experience :)