### PR TITLE
fix: add error case for TSTORE when context is static

### DIFF
--- a/docs/opcodes/5C.mdx
+++ b/docs/opcodes/5C.mdx
@@ -30,3 +30,4 @@ group: Stack Memory Storage and Flow Operations
 The state changes done by the current context are [reverted](#FD) in those cases:
 - Not enough gas.
 - Not enough values on the stack.
+- The current execution context is from a [STATICCALL](/#FA) (since Byzantium fork) or an [EXTSTATICCALL](/#FB) (since EOF fork).


### PR DESCRIPTION
Description:
- Specify in the `Error cases` section of the opcode that it will fail if the executed within a static context. 
 
[Execution Specs reference](https://github.com/ethereum/execution-specs/blob/2926c00c1d130e5d0641d278012d42267f3feaf3/src/ethereum/cancun/vm/instructions/storage.py#L171)

Closes #363 