### PR TITLE
hide sim banner

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -15,7 +15,6 @@ import { EthereumContext } from 'context/ethereumContext'
 import ContributeBox from 'components/ContributeBox'
 import HomeLayout from 'components/layouts/Home'
 import ReferenceTable from 'components/Reference'
-import SimBanner from 'components/SimBanner'
 import { H1, Container } from 'components/ui'
 
 const { serverRuntimeConfig } = getConfig()
@@ -39,7 +38,6 @@ const HomePage = ({
           content="An Ethereum Virtual Machine Opcodes Interactive Reference"
         />
       </Head>
-      <SimBanner />
       <Container>
         <H1>
           An Ethereum Virtual Machine <br></br> Opcodes Interactive Reference


### PR DESCRIPTION
Hides sim banner. Leaves code for the banner in case we want to repurpose later.